### PR TITLE
windows: Change wParam size to 64 bits

### DIFF
--- a/dali/internal/window-system/windows/platform-implement-win.cpp
+++ b/dali/internal/window-system/windows/platform-implement-win.cpp
@@ -138,7 +138,7 @@ void WindowImpl::SetListener( CallbackBase *callback )
 
 bool WindowImpl::PostWinMessage(
   _In_ uint32_t Msg,
-  _In_ uint32_t wParam,
+  _In_ uint64_t wParam,
   _In_ uint64_t lParam )
 {
   return (bool)PostMessage( reinterpret_cast<HWND>( mHWnd ), Msg, wParam, lParam );
@@ -216,7 +216,7 @@ void WindowImpl::SetWinProc()
 
 bool PostWinThreadMessage(
   _In_ uint32_t Msg,
-  _In_ uint32_t wParam,
+  _In_ uint64_t wParam,
   _In_ uint64_t lParam,
   _In_ uint64_t threadID/* = -1*/ )
 {

--- a/dali/internal/window-system/windows/platform-implement-win.h
+++ b/dali/internal/window-system/windows/platform-implement-win.h
@@ -39,7 +39,7 @@ namespace WindowsPlatformImplementation
 
 bool PostWinThreadMessage(
     _In_ uint32_t Msg,
-    _In_ uint32_t wParam,
+    _In_ uint64_t wParam,
     _In_ uint64_t lParam,
     _In_ uint64_t threadID = -1 );
 
@@ -83,7 +83,7 @@ public:
 
   bool PostWinMessage(
     _In_ uint32_t Msg,
-    _In_ uint32_t wParam,
+    _In_ uint64_t wParam,
     _In_ uint64_t lParam );
 
   int32_t GetEdgeWidth();


### PR DESCRIPTION
The wParam message parameter is used to send the callback object pointer
to WM_WIN_CALLBACK messages. As it is fixed as a 32 bit value in DALi,
when running on 64 bits systems it sends an invalid pointer to message
receiver.