### PR TITLE
platform-implement-win.cpp: Fix invalid pointer cast in 64 bits systems

### DIFF
--- a/dali/internal/system/windows/timer-impl-win.cpp
+++ b/dali/internal/system/windows/timer-impl-win.cpp
@@ -51,7 +51,7 @@ struct Timer::Impl
   {
   }
 
-  int mId;
+  intptr_t mId;
 
   unsigned int mInterval;
 };

--- a/dali/internal/window-system/windows/platform-implement-win.cpp
+++ b/dali/internal/window-system/windows/platform-implement-win.cpp
@@ -241,20 +241,20 @@ void CALLBACK TimerProc(HWND hWnd, UINT nMsg, UINT_PTR nTimerid, DWORD dwTime)
   info->callback( info->data );
 }
 
-int SetTimer(int interval, timerCallback callback, void *data)
+intptr_t SetTimer(int interval, timerCallback callback, void *data)
 {
   TTimerCallbackInfo *callbackInfo = new TTimerCallbackInfo;
   callbackInfo->data = data;
   callbackInfo->callback = callback;
   callbackInfo->hWnd = ::GetActiveWindow();
 
-  UINT_PTR timerID = (UINT_PTR)callbackInfo;
+  INT_PTR timerID = (INT_PTR)callbackInfo;
   ::SetTimer( callbackInfo->hWnd, timerID, interval, TimerProc );
 
   return timerID;
 }
 
-void KillTimer(int id)
+void KillTimer(intptr_t id)
 {
   TTimerCallbackInfo *info = (TTimerCallbackInfo*)id;
   ::KillTimer( info->hWnd, id );

--- a/dali/internal/window-system/windows/platform-implement-win.h
+++ b/dali/internal/window-system/windows/platform-implement-win.h
@@ -45,9 +45,9 @@ bool PostWinThreadMessage(
 
 using timerCallback = bool(*)(void *data);
 
-int SetTimer(int interval, timerCallback callback, void *data);
+intptr_t SetTimer(int interval, timerCallback callback, void *data);
 
-void KillTimer(int id);
+void KillTimer(intptr_t id);
 
 const char* GetKeyName( int keyCode );
 


### PR DESCRIPTION
The ID returned by the function SetTimer is actually a pointer to a data
structure storing the timer information. Originally the return type of
the function was int, which is 32 bits, but in Windows 64 bits it is not
enough to store a pointer value.

We convert the timer ID type to the proper type intptr_t, which is an
integral type guaranteed to be big enough to hold a pointer value.