### PR TITLE
windows: Store the window handle in a pointer sized type

### DIFF
--- a/dali/internal/window-system/windows/platform-implement-win.h
+++ b/dali/internal/window-system/windows/platform-implement-win.h
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <dali/public-api/signals/callback.h>
 
-typedef uint64_t   WinWindowHandle;
+typedef uintptr_t   WinWindowHandle;
 typedef uint64_t   WinPixmap;
 
 namespace Dali

--- a/dali/internal/window-system/windows/window-base-win.cpp
+++ b/dali/internal/window-system/windows/window-base-win.cpp
@@ -67,7 +67,7 @@ WindowBaseWin::~WindowBaseWin()
 void WindowBaseWin::Initialize( PositionSize positionSize, Any surface, bool isTransparent )
 {
   // see if there is a surface in Any surface
-  unsigned int surfaceId = GetSurfaceId( surface );
+  uintptr_t surfaceId = GetSurfaceId( surface );
 
   // if the surface is empty, create a new one.
   if( surfaceId == 0 )
@@ -462,9 +462,9 @@ void WindowBaseWin::SetTransparency( bool transparent )
 {
 }
 
-unsigned int WindowBaseWin::GetSurfaceId( Any surface ) const
+uintptr_t WindowBaseWin::GetSurfaceId( Any surface ) const
 {
-  unsigned int surfaceId = 0;
+  uintptr_t surfaceId = 0;
 
   if ( surface.Empty() == false )
   {
@@ -486,13 +486,13 @@ void WindowBaseWin::CreateWinWindow( PositionSize positionSize, bool isTranspare
   DALI_ASSERT_ALWAYS( mWin32Window != 0 && "There is no Windows window" );
 }
 
-void WindowBaseWin::SetWinWindow( unsigned int surfaceId )
+void WindowBaseWin::SetWinWindow( uintptr_t surfaceId )
 {
   HWND hWnd = (HWND)surfaceId;
 
   mWin32Window = static_cast<WinWindowHandle>(surfaceId);
 
-  mWindowImpl.SetHWND( reinterpret_cast<uint64_t>(hWnd));
+  mWindowImpl.SetHWND(surfaceId);
 
   mWindowImpl.SetWinProc();
 }

--- a/dali/internal/window-system/windows/window-base-win.h
+++ b/dali/internal/window-system/windows/window-base-win.h
@@ -363,7 +363,7 @@ private:
    * @param surface Any containing a surface id, or can be empty
    * @return surface id, or zero if surface is empty
    */
-  unsigned int GetSurfaceId( Any surface ) const;
+  uintptr_t GetSurfaceId( Any surface ) const;
 
   /**
    * @brief Create window
@@ -373,7 +373,7 @@ private:
   /**
    * @brief Sets up an already created window.
    */
-  void SetWinWindow( unsigned int surfaceId );
+  void SetWinWindow( uintptr_t surfaceId );
 
 private:
 


### PR DESCRIPTION
Under the hoods, HWND is a typedef to a void *, which is can't be stored
in the int in 64 bits systems.