### PR TITLE
Fix Undefined Behaviour when DALI_APPLICATION_PACKAGE is empty

### DIFF
--- a/dali/internal/adaptor/windows/framework-win.cpp
+++ b/dali/internal/adaptor/windows/framework-win.cpp
@@ -38,6 +38,10 @@ namespace Adaptor
 namespace
 {
 
+struct EmptyEnvVar : std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
 /// Application Status Enum
 enum
 {
@@ -255,15 +259,17 @@ std::string Framework::GetBundleId() const
 
 std::string Framework::GetResourcePath()
 {
+  using namespace std::string_literals;
   // "DALI_APPLICATION_PACKAGE" is used by Windows specifically to get the already configured Application package path.
   const char* winEnvironmentVariable = "DALI_APPLICATION_PACKAGE";
   char* value = getenv( winEnvironmentVariable );
 
-  std::string resourcePath;
-  if ( value != NULL )
+  if( !value )
   {
-    resourcePath = value;
+    throw EmptyEnvVar{winEnvironmentVariable + " is not set"s};
   }
+
+  std::string resourcePath = value;
 
   if( resourcePath.back() != '/' )
   {


### PR DESCRIPTION
In the following piece of code:

```c++
  const char* winEnvironmentVariable = "DALI_APPLICATION_PACKAGE";
  char* value = getenv( winEnvironmentVariable );

  std::string resourcePath;
  if( value != NULL )
  {
    resourcePath = value;
  }

  if( resourcePath.back() != '/' )
  {
    resourcePath+="/";
  }
```

When DALI_APPLICATION_PACKAGE is not set, since that is not handled in any way, `resourcePath` will have an empty string. So in `resourcePath.back()`, we'll be calling `back` in an empty string, [which is Undefined Behaviour](https://en.cppreference.com/w/cpp/string/basic_string/back).

This PR fixes it by handling the unset environment variable and throwing a specialized exception `EmptyEnvVar`.